### PR TITLE
remove quoted_date method

### DIFF
--- a/lib/active_record/connection_adapters/redshift/quoting.rb
+++ b/lib/active_record/connection_adapters/redshift/quoting.rb
@@ -40,21 +40,6 @@ module ActiveRecord
           PGconn.quote_ident(name.to_s)
         end
 
-        # Quote date/time values for use in SQL input. Includes microseconds
-        # if the value is a Time responding to usec.
-        def quoted_date(value) #:nodoc:
-          result = super
-          if value.acts_like?(:time) && value.respond_to?(:usec)
-            result = "#{result}.#{sprintf("%06d", value.usec)}"
-          end
-
-          if value.year <= 0
-            bce_year = format("%04d", -value.year + 1)
-            result = result.sub(/^-?\d+/, bce_year) + " BC"
-          end
-          result
-        end
-
         # Does not quote function default values for UUID columns
         def quote_default_value(value, column) #:nodoc:
           if column.type == :uuid && value =~ /\(\)/


### PR DESCRIPTION
When I tried to save a model using the rails timestamps feature to automatically add created_at and updated_at, I got an error because the formatted date had it's milliseconds duplicated, leading to an invalid date.

Removing this override fixed it, so maybe something changed from 4 to 5 to make this unnecessary?

I have not thoroughly tested this change, or run the automated test suite (there are no instructions in the readme for doing so), but it fixed my issue.